### PR TITLE
Add support for font-path option

### DIFF
--- a/cli-options.go
+++ b/cli-options.go
@@ -71,6 +71,7 @@ func (c *CLIOptions) Args() (result []string) {
 			}
 			paths += path
 		}
+		result = append(result, "--font-path", paths)
 	}
 
 	if c.IgnoreSystemFonts {


### PR DESCRIPTION
The font path option is present in the code but does not reflect in the command line nor environment passed to typst. This PR passes the set pathlist to the `--font-path`  option